### PR TITLE
update archlinux-keyring before initial full update in worker

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,14 +1,14 @@
 FROM archlinux:latest
 
 # base system + tools
-RUN pacman -Syu --noconfirm && \
-  pacman-key --init && \
+RUN pacman-key --init && \
   pacman-key --populate archlinux && \
-  pacman -S --noconfirm \
-  git vim python make gcc curl wget clang llvm
+  pacman -Sy --noconfirm archlinux-keyring && \
+  pacman -Syu --noconfirm && \
+  pacman -S --noconfirm git vim python make gcc curl wget clang llvm
 
 # install gosu for signals
-ENV GOSU_VERSION 1.19
+ENV GOSU_VERSION=1.19
 
 RUN curl -Lo /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64" && \
   chmod +x /usr/local/bin/gosu


### PR DESCRIPTION
just had to update `archlinux-keyring` first. otherwise the initial update failed with:

```
28.58 checking keyring...
28.65 checking package integrity... 
29.27 error: libseccomp: signature from "Levente Polyak (anthraxx) <levente@leventepolyak.net>" is unknown trust
29.27 :: File /var/cache/pacman/pkg/libseccomp-2.6.0-1-x86_64.pkg.tar.zst is corrupted (invalid or corrupted package (PGP signature)). 29.27 Do you want to delete it? [Y/n] error: failed to commit transaction (invalid or corrupted package)
29.30
29.30 Errors occurred, no packages were upgraded.
```