### PR TITLE
docs: update worker README for Alpine image and GHCR flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,17 @@
 
 ## Worker
 
-The worker uses an archlinux:latest base image and runs pacman updates in the background to
+The worker uses an `alpine:edge` base image and runs `apk` updates in the background to
 keep the software stack up to date.
 This is useful to get the latest compilers and tools for running the worker.
 The container also runs one update check before starting the workers.
 The update check runs every 12 hours.
 
-When the updater changes the `gcc` or `python` package, it creates `fish.exit` in each worker directory.
+When the updater changes the `gcc` or `python3` package, it creates `fish.exit` in each worker directory.
 This lets the workers finish their current batch of games and exit cleanly before Docker
 starts them again, so the next startup sees fresh compiler metadata.
+
+By default, the worker pulls a pre-built image from GitHub Container Registry.
 
 ```
 cd worker


### PR DESCRIPTION
## Summary

- Update worker docs to reflect the Alpine-based image and apk updater
- Document the default GHCR pre-built image flow

## Motivation

The README still described the previous Arch Linux / pacman workflow. This updates it to match the current worker setup.

## Test plan

- [x] Reviewed README against current worker Dockerfile and compose files