### PR TITLE
fix: correct worker image workflow trigger path

### DIFF
--- a/.github/workflows/worker-image.yml
+++ b/.github/workflows/worker-image.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
     paths:
       - "worker/**"
-      - ".github/workflows/docker-worker.yml"
+      - ".github/workflows/worker-image.yml"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Fix the path filter in the worker image CI workflow so changes to the workflow file itself trigger rebuilds.

## Motivation

The workflow trigger referenced \.github\workflows\docker-worker.yml, but the actual file is worker-image.yml. Edits to the workflow alone would not trigger the build.

## Test plan

- [x] Verified the corrected path matches the actual workflow filename