### PR TITLE
fix: clean up worker Dockerfile

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -15,8 +15,7 @@ RUN apk update && apk add --no-cache \
     wget \
     clang \
     llvm \
-    shadow \
-    su-exec
+    shadow
 
 # updater stays as root
 COPY updater.sh /updater.sh
@@ -49,7 +48,7 @@ COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 ENV NUM_WORKERS=""
-ENV WORKER_CONFIG=""
+ENV WORKER_ARGS=""
 
 # run updater in background and then start your workers
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
## Summary

- Rename WORKER_CONFIG to WORKER_ARGS to match compose and run_workers.sh
- Remove unused su-exec package since entrypoint.sh uses gosu

## Motivation

Both changes are small cleanups in \worker\Dockerfile.

## Test plan

- [x] Confirmed compose.yml and run_workers.sh use WORKER_ARGS
- [x] Confirmed entrypoint.sh uses gosu, not su-exec