### PR TITLE
feat: make env_file explicit in worker compose

### DIFF
--- a/worker/compose.yml
+++ b/worker/compose.yml
@@ -7,6 +7,8 @@ services:
     stdin_open: true # docker run -i
     tty: true        # docker run -t
     shm_size: '1gb'  # for shared network
+    env_file:
+      - .env
     environment:
       - NUM_WORKERS
       - WORKER_ARGS


### PR DESCRIPTION
## Summary

Add an explicit env_file: .env entry to the worker compose file.

## Motivation

Docker Compose auto-loads .env for variable substitution, but making it explicit makes the setup clearer for new contributors and matches common compose conventions.

## Test plan

- [x] Verified worker starts correctly with existing .env file