### PR TITLE
chore: remove unused su-exec package from worker Dockerfile

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -15,8 +15,7 @@ RUN apk update && apk add --no-cache \
     wget \
     clang \
     llvm \
-    shadow \
-    su-exec
+    shadow
 
 # updater stays as root
 COPY updater.sh /updater.sh


### PR DESCRIPTION
## Summary

Remove the \su-exec\ package from the worker Dockerfile.

## Motivation

The Dockerfile installs \su-exec\ but entrypoint.sh uses \gosu\ for dropping privileges. Removing the unused package slightly reduces image size and dependency clutter.

## Test plan

- [x] Confirmed entrypoint.sh uses gosu, not su-exec

Made with [Cursor](https://cursor.com)